### PR TITLE
Stop erring when exposing multiple functions with the same name.

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -270,8 +270,8 @@ def _call_return(call):
 
 def _expose(name, function):
     msg = 'Already exposed function with name "%s"' % name
-    assert name not in _exposed_functions, msg
-    _exposed_functions[name] = function
+    if name not in _exposed_functions:
+        _exposed_functions[name] = function        
 
 
 def _websocket_close(page):


### PR DESCRIPTION
Currently, Eel will exit if multiple exposed python functions have the same name. However, this is as issue if two different python files import each other.

For example:
If fileA.py looks like this:
```
import eel
import fileB

@eel.expose
def function1():
    print("Function 1")
```
and fileB.py looks like this:
```
import eel
import fileA

@eel.expose
def function2():
    print("Function 2")
```
Then the program will exit as it re-reads fileA, thinking that a python function with the name `function1` has already been exposed but not taking into account that it is actually the same function.

The above change does not change any functionality and after doing some testing I do not think it breaks anything.