### PR TITLE
Moved websocket setup logic into a public method. 

### DIFF
--- a/eel/eel.js
+++ b/eel/eel.js
@@ -5,6 +5,49 @@ eel = {
         eel._host = hostname
     },
 
+    oninit: null,
+
+    ws_init: function() {
+        let page = window.location.pathname.substring(1);
+        eel._position_window(page);
+
+        let websocket_addr = (eel._host + '/eel').replace('http', 'ws');
+        websocket_addr += ('?page=' + page);
+        eel._websocket = new WebSocket(websocket_addr);
+
+        eel._websocket.onopen = function() {
+            for(let i = 0; i < eel._py_functions.length; i++){
+                let py_function = eel._py_functions[i];
+                eel._import_py_function(py_function);
+            }
+
+            while(eel._mock_queue.length > 0) {
+                let call = eel._mock_queue.shift();
+                eel._websocket.send(eel._toJSON(call));
+            }
+
+            if(eel.oninit) eel.oninit();
+        };
+
+        eel._websocket.onmessage = function (e) {
+            let message = JSON.parse(e.data);
+            if(message.hasOwnProperty('call') ) {
+                // Python making a function call into us
+                if(message.name in eel._exposed_functions) {
+                    let return_val = eel._exposed_functions[message.name](...message.args);
+                    eel._websocket.send(eel._toJSON({'return': message.call, 'value': return_val}));
+                }
+            } else if(message.hasOwnProperty('return')) {
+                // Python returning a value to us
+                if(message['return'] in eel._call_return_callbacks) {
+                    eel._call_return_callbacks[message['return']](message.value);
+                }
+            } else {
+                throw 'Invalid message ' + message;
+            }
+        };
+    },
+
     expose: function(f, name) {
         if(name === undefined){
             name = f.toString();
@@ -107,43 +150,7 @@ eel = {
         eel._mock_py_functions();
 
         document.addEventListener("DOMContentLoaded", function(event) {
-            let page = window.location.pathname.substring(1);
-            eel._position_window(page);
-
-            let websocket_addr = (eel._host + '/eel').replace('http', 'ws');
-            websocket_addr += ('?page=' + page);
-            eel._websocket = new WebSocket(websocket_addr);
-
-            eel._websocket.onopen = function() {
-                for(let i = 0; i < eel._py_functions.length; i++){
-                    let py_function = eel._py_functions[i];
-                    eel._import_py_function(py_function);
-                }
-
-                while(eel._mock_queue.length > 0) {
-                    let call = eel._mock_queue.shift();
-                    eel._websocket.send(eel._toJSON(call));
-                }
-            };
-
-            eel._websocket.onmessage = function (e) {
-                let message = JSON.parse(e.data);
-                if(message.hasOwnProperty('call') ) {
-                    // Python making a function call into us
-                    if(message.name in eel._exposed_functions) {
-                        let return_val = eel._exposed_functions[message.name](...message.args);
-                        eel._websocket.send(eel._toJSON({'return': message.call, 'value': return_val}));
-                    }
-                } else if(message.hasOwnProperty('return')) {
-                    // Python returning a value to us
-                    if(message['return'] in eel._call_return_callbacks) {
-                        eel._call_return_callbacks[message['return']](message.value);
-                    }
-                } else {
-                    throw 'Invalid message ' + message;
-                }
-
-            };
+            ws_init();
         });
     }
 }


### PR DESCRIPTION
Moved websocket setup logic into a public method and added a callback to get notification on successful connection with the Python backend.

Since the websocket  setup logic is tied to 'DOMContentLoaded' event, the initialization does not occur if Eel is added later (lazy loading in React for example). This change retains backwards compatibility but allows the websockets to be initialized manually. The oninit callback allows a bit more control for orchestrating creation of components and feedback to user. 