### PR TITLE
Allow a Bottle instance to be passed to Eel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### v0.11.0 (not yet released)
+* Added support for `app` parameter to `eel.start`, which will override the bottle app instance used to run eel. This 
+allows developers to apply any middleware they wish to before handing over to eel.
+
 ### v0.10.4
 * Fix PyPi project description.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ As of Eel 1.0.0, the following options are available to `start()`:
  - **position**, a tuple of ints specifying the (left, top) of the main window in pixels *Default: `None`*
  - **geometry**, a dictionary specifying the size and position for all windows. The keys should be the relative path of the page, and the values should be a dictionary of the form `{'size': (200, 100), 'position': (300, 50)}`. *Default: {}*
  - **close_callback**, a lambda or function that is called when a websocket to a window closes (i.e. when the user closes the window). It should take two arguments; a string which is the relative path of the page that just closed, and a list of other websockets that are still open. *Default: `None`*
+ - **app**, an instance of Bottle which will be used rather than creating a fresh one. This can be used to install middleware on the
+ instance before starting eel, e.g. for session management, authentication, etc.
 
 
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Additional options can be passed to `eel.start()` as keyword arguments.
 
 Some of the options include the mode the app is in (e.g. 'chrome'), the port the app runs on, the host name of the app, and adding additional command line flags.
 
-As of Eel 1.0.0, the following options are available to `start()`:
+As of Eel v0.11.0, the following options are available to `start()`:
  - **mode**, a string specifying what browser to use (e.g. `'chrome'`, `'electron'`, `'edge'`, `'custom'`). Can also be `None` or `False` to not open a window. *Default: `'chrome'`*
  - **host**, a string specifying what hostname to use for the Bottle server. *Default: `'localhost'`)*
  - **port**, an int specifying what port to use for the Bottle server. Use `0` for port to be picked automatically. *Default: `8000`*.

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -40,6 +40,7 @@ _start_args = {
     'app_mode':  True,                              # (Chrome specific option)
     'all_interfaces': False,                        # Allow bottle server to listen for connections on all interfaces
     'disable_cache': True,                          # Sets the no-store response header when serving assets
+    'app': None,                                    # Allows passing in a custom Bottle instance, e.g. with middleware
 }
 
 # == Temporary (suppressable) error message to inform users of breaking API change for v1.0.0 ===
@@ -141,7 +142,8 @@ def start(*start_urls, **kwargs):
             host=HOST,
             port=_start_args['port'],
             server=wbs.GeventWebSocketServer,
-            quiet=True)
+            quiet=True,
+            app=_start_args.get('app'))
 
     # Start the webserver
     if _start_args['block']:


### PR DESCRIPTION
This will allow end users to create their own Bottle app and inject any
middleware they want, e.g. to handle authentication or session
management, before Eel takes over.

Resolves #199