### PR TITLE
Fix wrong arguments for URL to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Eel is a little Python library for making simple Electron-like offline HTML/JS G
 
 Eel is designed to take the hassle out of writing short and simple GUI applications. If you are familiar with Python and web development, probably just jump to [this example](https://github.com/ChrisKnott/Eel/tree/master/examples/04%20-%20file_access) which picks random file names out of the given folder (something that is impossible from a browser).
 
-<p align="center"><img src="examples/04%20-%20file_access/Screenshot.png" ></p>
+<p align="center"><img src="https://raw.githubusercontent.com/samuelhwilliams/Eel/master/examples/04%20-%20file_access/Screenshot.png" ></p>
 
 <!-- TOC -->
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 from io import open
 from setuptools import setup
 
+with open('README.md') as read_me:
+    long_description = read_me.read()
+
 setup(
     name='Eel',
     version='0.11.0',
     author='Chris Knott',
     author_email='chrisknott@hotmail.co.uk',
+    url='https://github.com/samuelhwilliams/Eel',
     packages=['eel'],
     package_data={
         'eel': ['eel.js'],
@@ -13,7 +17,6 @@ setup(
     install_requires=['bottle', 'bottle-websocket', 'future', 'whichcraft'],
     python_requires='>=2.6',
     description='For little HTML GUI applications, with easy Python/JS interop',
-    long_description=open('README.md', encoding='utf-8').readlines()[2],
+    long_description=long_description,
     keywords=['gui', 'html', 'javascript', 'electron'],
-    homepage='https://github.com/ChrisKnott/Eel',
 )

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
     python_requires='>=2.6',
     description='For little HTML GUI applications, with easy Python/JS interop',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords=['gui', 'html', 'javascript', 'electron'],
 )


### PR DESCRIPTION
Warehouse now uses the `url` provided to display links in the sidebar, as well as including them in API responses to help automation tool find the source code for Eel. For example, see Django's [setup.cfg](https://github.com/django/django/blob/master/setup.cfg) and [PyPI listing](https://pypi.org/project/Django/).

PyPI also already support rendering project descriptions from Markdown https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/