### PR TITLE
Fix routing for custom bottles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### v0.11.1
+* Fix the implementation of #203, allowing users to pass their own bottle instances into Eel.
+
 ### v0.11.0
 * Added support for `app` parameter to `eel.start`, which will override the bottle app instance used to run eel. This 
 allows developers to apply any middleware they wish to before handing over to eel.

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -40,7 +40,7 @@ _start_args = {
     'app_mode':  True,                              # (Chrome specific option)
     'all_interfaces': False,                        # Allow bottle server to listen for connections on all interfaces
     'disable_cache': True,                          # Sets the no-store response header when serving assets
-    'app': None,                                    # Allows passing in a custom Bottle instance, e.g. with middleware
+    'app': btl.default_app(),                       # Allows passing in a custom Bottle instance, e.g. with middleware
 }
 
 # == Temporary (suppressable) error message to inform users of breaking API change for v1.0.0 ===
@@ -139,7 +139,7 @@ def start(*start_urls, **kwargs):
         else:
             HOST = _start_args['host']
 
-        app = _start_args.get('app', btl.default_app)  # type: btl.Bottle
+        app = _start_args['app']  # type: btl.Bottle
         for route_path, route_params in BOTTLE_ROUTES.items():
             route_func, route_kwargs = route_params
             app.route(path=route_path, callback=route_func, **route_kwargs)

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -138,12 +138,18 @@ def start(*start_urls, **kwargs):
             HOST = '0.0.0.0'
         else:
             HOST = _start_args['host']
+
+        app = _start_args.get('app', btl.default_app)  # type: btl.Bottle
+        for route_path, route_params in BOTTLE_ROUTES.items():
+            route_func, route_kwargs = route_params
+            app.route(path=route_path, callback=route_func, **route_kwargs)
+
         return btl.run(
             host=HOST,
             port=_start_args['port'],
             server=wbs.GeventWebSocketServer,
             quiet=True,
-            app=_start_args.get('app'))
+            app=app)
 
     # Start the webserver
     if _start_args['block']:
@@ -165,7 +171,6 @@ def spawn(function, *args, **kwargs):
 
 # Bottle Routes
 
-@btl.route('/eel.js')
 def _eel():
     start_geometry = {'default': {'size': _start_args['size'],
                                   'position': _start_args['position']},
@@ -179,8 +184,6 @@ def _eel():
     _set_response_headers(btl.response)
     return page
 
-
-@btl.route('/<path:path>')
 def _static(path):
     response = None
     if 'jinja_env' in _start_args and 'jinja_templates' in _start_args:
@@ -196,8 +199,6 @@ def _static(path):
     _set_response_headers(response)
     return response
 
-
-@btl.get('/eel', apply=[wbs.websocket])
 def _websocket(ws):
     global _websockets
 
@@ -222,6 +223,13 @@ def _websocket(ws):
             break
 
     _websocket_close(page)
+
+
+BOTTLE_ROUTES = {
+    "/eel.js": (_eel, dict()),
+    "/<path:path>": (_static, dict()),
+    "/eel": (_websocket, dict(apply=[wbs.websocket]))
+}
 
 # Private functions
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='Eel',
-    version='0.11.0',
+    version='0.11.1',
     author='Chris Knott',
     author_email='chrisknott@hotmail.co.uk',
     packages=['eel'],


### PR DESCRIPTION
PR #203 added the ability for users to pass a custom Bottle instance to
Eel, which was intended to help them add middleware. Unfortunately, the
custom app instance has no routing set up and so fundamentally fails to
support Eel's functionality.

This patch applies the functions that handle routing to any custom
bottles before handing off off to bottle to run the server.

Fix #211