### PR TITLE
Allow user-configurable timeout on JS execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Change log
 
+## v0.12.0
+* Allow users to override the amount of time Python will wait for Javascript functions running via Eel to run before bailing and returning None.
+
 ### v0.11.1
 * Fix the implementation of #203, allowing users to pass their own bottle instances into Eel.
 
-### v0.11.0
-* Added support for `app` parameter to `eel.start`, which will override the bottle app instance used to run eel. This 
+## v0.11.0
+* Added support for `app` parameter to `eel.start`, which will override the bottle app instance used to run eel. This
 allows developers to apply any middleware they wish to before handing over to eel.
 * Disable page caching by default via new `disable_cache` parameter to `eel.start`.
 * Add support for listening on all network interfaces via new `all_interfaces` parameter to `eel.start`.
@@ -14,7 +17,7 @@ allows developers to apply any middleware they wish to before handing over to ee
 * Fix PyPi project description.
 
 ### v0.10.3
-* Fix a bug that prevented using Eel without Jinja templating. 
+* Fix a bug that prevented using Eel without Jinja templating.
 
 ### v0.10.2
 * Only render templates from within the declared jinja template directory.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ While we want to think of our code as comprising a single application, the Pytho
 Eel supports two ways of retrieving _return values_ from the other side of the app, which helps keep the code concise.
 
 To prevent hanging forever on the Python side, a timeout has been put in place for trying to retrieve values from
-the JavaScript side, which defaults to 10000 milliseconds (10 seconds). This can be changed with the `max_js_runtime` parameter to `eel.init`. There is no corresponding timeout on the JavaScript side.
+the JavaScript side, which defaults to 10000 milliseconds (10 seconds). This can be changed with the `_js_result_timeout` parameter to `eel.init`. There is no corresponding timeout on the JavaScript side.
 
 #### Callbacks
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Additional options can be passed to `eel.start()` as keyword arguments.
 
 Some of the options include the mode the app is in (e.g. 'chrome'), the port the app runs on, the host name of the app, and adding additional command line flags.
 
-As of Eel v0.11.0, the following options are available to `start()`:
+As of Eel v0.12.0, the following options are available to `start()`:
  - **mode**, a string specifying what browser to use (e.g. `'chrome'`, `'electron'`, `'edge'`, `'custom'`). Can also be `None` or `False` to not open a window. *Default: `'chrome'`*
  - **host**, a string specifying what hostname to use for the Bottle server. *Default: `'localhost'`)*
  - **port**, an int specifying what port to use for the Bottle server. Use `0` for port to be picked automatically. *Default: `8000`*.
@@ -220,6 +220,9 @@ You will notice that in the Python code, the Javascript function is called befor
 While we want to think of our code as comprising a single application, the Python interpreter and the browser window run in separate processes. This can make communicating back and forth between them a bit of a mess, especially if we always had to explicitly _send_ values from one side to the other.
 
 Eel supports two ways of retrieving _return values_ from the other side of the app, which helps keep the code concise.
+
+To prevent hanging forever on the Python side, a timeout has been put in place for trying to retrieve values from
+the JavaScript side, which defaults to 10000 milliseconds (10 seconds). This can be changed with the `max_js_runtime` parameter to `eel.init`. There is no corresponding timeout on the JavaScript side.
 
 #### Callbacks
 

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -25,6 +25,10 @@ _js_functions = []
 _mock_queue = []
 _mock_queue_done = set()
 
+# The maximum time (in milliseconds) that Python will try to retrieve a return value for functions executing in JS
+# Can be overridden through `eel.init` with the kwarg `max_js_runtime` (default: 10000)
+_max_js_runtime = 10000
+
 # All start() options must provide a default value and explanation here
 _start_args = {
     'mode':             'chrome',                   # What browser is used
@@ -75,8 +79,8 @@ def expose(name_or_function=None):
 
 
 def init(path, allowed_extensions=['.js', '.html', '.txt', '.htm',
-                                   '.xhtml', '.vue']):
-    global root_path, _js_functions
+                                   '.xhtml', '.vue'], max_js_runtime=10000):
+    global root_path, _js_functions, _max_js_runtime
     root_path = _get_real_path(path)
 
     js_functions = set()
@@ -106,6 +110,8 @@ def init(path, allowed_extensions=['.js', '.html', '.txt', '.htm',
     _js_functions = list(js_functions)
     for js_function in _js_functions:
         _mock_js_function(js_function)
+
+    _max_js_runtime = max_js_runtime
 
 
 def start(*start_urls, **kwargs):
@@ -299,13 +305,14 @@ def _js_call(name, args):
 
 
 def _call_return(call):
+    global _max_js_runtime
     call_id = call['call']
 
     def return_func(callback=None):
         if callback is not None:
             _call_return_callbacks[call_id] = callback
         else:
-            for w in range(10000):
+            for w in range(_max_js_runtime):
                 if call_id in _call_return_values:
                     return _call_return_values.pop(call_id)
                 sleep(0.001)

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -26,8 +26,8 @@ _mock_queue = []
 _mock_queue_done = set()
 
 # The maximum time (in milliseconds) that Python will try to retrieve a return value for functions executing in JS
-# Can be overridden through `eel.init` with the kwarg `max_js_runtime` (default: 10000)
-_max_js_runtime = 10000
+# Can be overridden through `eel.init` with the kwarg `js_result_timeout` (default: 10000)
+_js_result_timeout = 10000
 
 # All start() options must provide a default value and explanation here
 _start_args = {
@@ -79,8 +79,8 @@ def expose(name_or_function=None):
 
 
 def init(path, allowed_extensions=['.js', '.html', '.txt', '.htm',
-                                   '.xhtml', '.vue'], max_js_runtime=10000):
-    global root_path, _js_functions, _max_js_runtime
+                                   '.xhtml', '.vue'], js_result_timeout=10000):
+    global root_path, _js_functions, _js_result_timeout
     root_path = _get_real_path(path)
 
     js_functions = set()
@@ -111,7 +111,7 @@ def init(path, allowed_extensions=['.js', '.html', '.txt', '.htm',
     for js_function in _js_functions:
         _mock_js_function(js_function)
 
-    _max_js_runtime = max_js_runtime
+    _js_result_timeout = js_result_timeout
 
 
 def start(*start_urls, **kwargs):
@@ -305,14 +305,14 @@ def _js_call(name, args):
 
 
 def _call_return(call):
-    global _max_js_runtime
+    global _js_result_timeout
     call_id = call['call']
 
     def return_func(callback=None):
         if callback is not None:
             _call_return_callbacks[call_id] = callback
         else:
-            for w in range(_max_js_runtime):
+            for w in range(_js_result_timeout):
                 if call_id in _call_return_values:
                     return _call_return_values.pop(call_id)
                 sleep(0.001)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as read_me:
 
 setup(
     name='Eel',
-    version='0.11.1',
+    version='0.12.0',
     author='Chris Knott',
     author_email='chrisknott@hotmail.co.uk',
     url='https://github.com/samuelhwilliams/Eel',


### PR DESCRIPTION
Python currently tries for 10 seconds, checking every millisecond, to
collect values returned by Javascript functions called via Eel. Some
users might expect their functions to execute longer than this, and so
it feels reasonable to allow users to configure this to be longer (or
shorter) as suits their needs.

Resolves #182