### PR TITLE
Add datetime support to eel websockets.

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -3,6 +3,7 @@ from builtins import range
 from io import open
 
 import gevent as gvt
+import datetime as dt
 import json as jsn
 import bottle as btl
 import bottle.ext.websocket as wbs
@@ -239,8 +240,16 @@ BOTTLE_ROUTES = {
 
 # Private functions
 
+def _jsn_converter(obj):
+    if isinstance(obj, dt.datetime):
+        return obj.__str__()
+    else:
+        # default case.
+        return None
+
+
 def _safe_json(obj):
-    return jsn.dumps(obj, default=lambda o: None)
+    return jsn.dumps(obj, default=_jsn_converter)
 
 
 def _repeated_send(ws, msg):


### PR DESCRIPTION
Added the ability to just coerce datetime objects directly into their `__str__` output when being sent down the pipe through a web-socket.

The main use case for this (at least for my current usage of Eel) is as follows:

- I'm using different models to store sets of data that flow between the frontend and backend.
- One of the main pieces of functionality for my application is allowing real-time updates and the inclusion of counters and stopwatches (that start from, or countdown to) a datetime object.
- Returning a dictionary that contains raw datetime objects currently just coerces them to a `None` type value or `null` when viewed in the JavaScript itself.

Now, I could just coerce my datetime objects into strings directly _before_ sending them down the pipe to be sent through a web-socket, but this would then mean that I need to convert them back to datetime objects when I'm dealing with them back in Python.

I think it's more worthwhile to just convert datetimes into strings by default when they're encountered by the `jsn.dumps` functionality within Eel.