### PR TITLE
tracking of browser process / waiting for browser close / update start args / couple of example fixes

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -183,6 +183,17 @@ def get_browser_process():
     return _spawned_process_list
 
 
+def wait_browser_close():
+    """Wait for all browser process's to close"""
+    for item in _spawned_process_list:
+        item.wait()
+
+
+def update_startargs(**kwargs):
+    """Update the start args directly, where we want to call show directly"""
+    _start_args.update(kwargs)
+
+
 # Bottle Routes
 
 def _eel():

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -24,6 +24,7 @@ _exposed_functions = {}
 _js_functions = []
 _mock_queue = []
 _mock_queue_done = set()
+_spawned_process_list = []
 
 # The maximum time (in milliseconds) that Python will try to retrieve a return value for functions executing in JS
 # Can be overridden through `eel.init` with the kwarg `js_result_timeout` (default: 10000)
@@ -165,7 +166,8 @@ def start(*start_urls, **kwargs):
 
 
 def show(*start_urls):
-    brw.open(start_urls, _start_args)
+    global _spawned_process_list
+    _spawned_process_list = brw.open(start_urls, _start_args)
 
 
 def sleep(seconds):
@@ -174,6 +176,12 @@ def sleep(seconds):
 
 def spawn(function, *args, **kwargs):
     gvt.spawn(function, *args, **kwargs)
+
+
+def get_browser_process():
+    """Get a list of all browser process's opened via Popen"""
+    return _spawned_process_list
+
 
 # Bottle Routes
 

--- a/eel/browsers.py
+++ b/eel/browsers.py
@@ -41,15 +41,17 @@ def _build_urls(start_pages, options):
 def open(start_pages, options):
     # Build full URLs for starting pages (including host and port)
     start_urls = _build_urls(start_pages, options)
-    
+    proclist = []
+
     mode = options.get('mode')
     if mode in [None, False]:
         # Don't open a browser
         pass
     elif mode == 'custom':
         # Just run whatever command the user provided
-        sps.Popen(options['cmdline_args'],
-                  stdout=sps.PIPE, stderr=sps.PIPE, stdin=sps.PIPE)
+        procitem = sps.Popen(options['cmdline_args'],
+                      stdout=sps.PIPE, stderr=sps.PIPE, stdin=sps.PIPE)
+        proclist.append(procitem)
     elif mode in _browser_modules:
         # Run with a specific browser
         browser_module = _browser_modules[mode]
@@ -60,13 +62,14 @@ def open(start_pages, options):
             _browser_paths[mode] = path
 
         if path is not None:
-            browser_module.run(path, options, start_urls)
+            proclist = browser_module.run(path, options, start_urls)
         else:
             raise EnvironmentError("Can't find %s installation" % browser_module.name)
     else:
         # Fall back to system default browser
         for url in start_urls:
             wbr.open(url)
+    return proclist
 
 
 def set_path(browser_name, path):

--- a/eel/chrome.py
+++ b/eel/chrome.py
@@ -5,15 +5,19 @@ import sys, subprocess as sps, os
 name = 'Google Chrome/Chromium'
 
 def run(path, options, start_urls):
+    proclist = []
     if options['app_mode']:
         for url in start_urls:
-            sps.Popen([path, '--app=%s' % url] +
-                       options['cmdline_args'],
-                       stdout=sps.PIPE, stderr=sps.PIPE, stdin=sps.PIPE)
+            procitem = sps.Popen([path, '--app=%s' % url] +
+                           options['cmdline_args'],
+                           stdout=sps.PIPE, stderr=sps.PIPE, stdin=sps.PIPE)
+            proclist.append(procitem)
     else:
         args = options['cmdline_args'] + start_urls
-        sps.Popen([path, '--new-window'] + args,
+        procitem = sps.Popen([path, '--new-window'] + args,
                    stdout=sps.PIPE, stderr=sys.stderr, stdin=sps.PIPE)
+        proclist.append(procitem)
+    return proclist
 
 
 def find_path():

--- a/eel/edge.py
+++ b/eel/edge.py
@@ -5,8 +5,11 @@ name = 'Edge'
 
 
 def run(_path, options, start_urls):
+    proclist = []
     cmd = 'start microsoft-edge:{}'.format(start_urls[0])
-    sps.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, stdin=sps.PIPE, shell=True)
+    procitem = sps.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, stdin=sps.PIPE, shell=True)
+    proclist.append(procitem)
+    return proclist
 
 
 def find_path():

--- a/eel/electron.py
+++ b/eel/electron.py
@@ -6,10 +6,12 @@ import whichcraft as wch
 name = 'Electron'
 
 def run(path, options, start_urls):
+    proclist = []
     cmd = [path] + options['cmdline_args']
     cmd += ['.', ';'.join(start_urls)]
-    sps.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, stdin=sps.PIPE)
-
+    procitem = sps.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, stdin=sps.PIPE)
+    proclist.append(procitem)
+    return proclist
 
 def find_path():
     if sys.platform in ['win32', 'win64']:

--- a/examples/01 - hello_world-Edge/hello.py
+++ b/examples/01 - hello_world-Edge/hello.py
@@ -29,7 +29,7 @@ else:
 
 # # Launching Edge can also be gracefully handled as a fall back
 # try:
-#     eel.start('hello.html', mode='chrome-app', size=(300, 200))
+#     eel.start('hello.html', mode='chrome', size=(300, 200))
 # except EnvironmentError:
 #     # If Chrome isn't found, fallback to Microsoft Edge on Win10 or greater
 #     if sys.platform in ['win32', 'win64'] and int(platform.release()) >= 10:

--- a/examples/07 - CreateReactApp/eel_CRA.py
+++ b/examples/07 - CreateReactApp/eel_CRA.py
@@ -46,7 +46,7 @@ def start_eel(develop):
         page = {'port': 3000}
     else:
         directory = 'build'
-        app = 'chrome-app'
+        app = 'chrome'
         page = 'index.html'
 
     eel.init(directory, ['.tsx', '.ts', '.jsx', '.js', '.html'])


### PR DESCRIPTION
Hi,
I've added a couple of changes

First I've added tracking of the browser process's launched
this can be retrieved via **get_browser_process()**
the idea is to use this to determine when the browser process has closed
so the python side can then close as well at the same time

Next there's a method called **wait_browser_close()**
this can be used to wait for browser instances to close

Next I've added a **update_startargs()** method, just to avoid accessing _start_args directly
What I'm doing is just using eel to launch chrome in application mode, but using a flask app as the backend

something like this
``` python

# Run Flask first
flaskserv.get_free_port()
flaskserv.start_async()

eel.update_startargs(size=(300, 200), mode='chrome', port=flaskserv.Port)
eel.show('/')
eel.wait_browser_close()
```
So instead of running the inbuilt bottle server, I'm running flask in a thread
(marked as a daemon so that it terminates when the main thread finishes)
then once we get past wait_browser_close() the whole app closes threads and all
