### PR TITLE
Update docs to show exposing js function with custom name (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ print('Calling Javascript...')
 eel.my_javascript_function(1, 2, 3, 4)  # This calls the Javascript function
 ```
 
+The exposed name can also be specified with in a second argument...
+
+```javascript
+eel.expose(someFunction, "my_javascript_function");
+```
+
 When passing complex objects as arguments, bear in mind that internally they are converted to JSON and sent down a websocket (a process that potentially loses information).
 
 ### Eello, World!


### PR DESCRIPTION
Adding documentation that shows how to specify a custom name for exposed JS functions.
This is useful for apps that are minified when built and the function names are changed.