### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Eel.egg-info
 *.pyc
 *.swp
 venv/
+.idea


### PR DESCRIPTION
.idea is the IDE directory of PyCharm. It should be in .gitignore file