### PR TITLE
fix(mac,chrome): search for chromium also

### DIFF
--- a/eel/chrome.py
+++ b/eel/chrome.py
@@ -20,7 +20,7 @@ def find_path():
     if sys.platform in ['win32', 'win64']:
         return _find_chrome_win()
     elif sys.platform == 'darwin':
-        return _find_chrome_mac()
+        return _find_chrome_mac() or _find_chromium_mac()
     elif sys.platform.startswith('linux'):
         return _find_chrome_linux()
     else:
@@ -33,9 +33,21 @@ def _find_chrome_mac():
         return default_dir
     # use mdfind ci to locate Chrome in alternate locations and return the first one
     name = 'Google Chrome.app'
-    alternate_dirs = [x for x in sps.check_output(["mdfind", name]).decode().split('\n') if x.endswith(name)] 
+    alternate_dirs = [x for x in sps.check_output(["mdfind", name]).decode().split('\n') if x.endswith(name)]
     if len(alternate_dirs):
         return alternate_dirs[0] + '/Contents/MacOS/Google Chrome'
+    return None
+
+
+def _find_chromium_mac():
+    default_dir = r'/Applications/Chromium.app/Contents/MacOS/Chromium'
+    if os.path.exists(default_dir):
+        return default_dir
+    # use mdfind ci to locate Chromium in alternate locations and return the first one
+    name = 'Chromium.app'
+    alternate_dirs = [x for x in sps.check_output(["mdfind", name]).decode().split('\n') if x.endswith(name)]
+    if len(alternate_dirs):
+        return alternate_dirs[0] + '/Contents/MacOS/Chromium'
     return None
 
 


### PR DESCRIPTION
I added support for searching for Chromium also (if Chrome is not found). This feature is useful because I am running Eel inside CI for multi-platform image recognition tests on Travis-CI and Chrome at first start on new environment is demanding user interaction before launching anything useful, on the other hand Chromium does not do that.