### PR TITLE
Set JS mimetype

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -13,7 +13,9 @@ import random as rnd
 import sys
 import pkg_resources as pkg
 import socket
+import mimetypes
 
+mimetypes.add_type('application/javascript', '.js')
 _eel_js_file = pkg.resource_filename('eel', 'eel.js')
 _eel_js = open(_eel_js_file, encoding='utf-8').read()
 _websockets = []


### PR DESCRIPTION
#49 #181 it seems like these issues weren't ever truly fixed.

It would be nice if Eel set the mimetypes on its own. According to https://github.com/pallets/flask/issues/1045 this bug will happen for all Windows users.

The most common use for this would be to import JS modules. Chrome doesn't allow modules with incorrect mimetypes to be loaded without a registry edit.

mimetypes is a Python standard lib so there shouldn't be much impact.

Cheers!