### PR TITLE
Updated spawn function to return Greenlet object

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -173,7 +173,7 @@ def sleep(seconds):
 
 
 def spawn(function, *args, **kwargs):
-    gvt.spawn(function, *args, **kwargs)
+    return gvt.spawn(function, *args, **kwargs)
 
 # Bottle Routes
 


### PR DESCRIPTION
For [Issue-58](https://github.com/samuelhwilliams/Eel/issues/58) added the return keyword.