### PR TITLE
Off-load pyinstaller config to its hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ while True:
 If you want to package your app into a program that can be run on a computer without a Python interpreter installed, you should use **PyInstaller**.
 
 1. Configure a virtualenv with desired Python version and minimum necessary Python packages
-2. Install PyInstaller `pip install PyInstaller`
+2. Install Eel with extra packages to simplify distribution `pip install eel[distribution]`. Eel currently uses [PyInstaller](https://www.pyinstaller.org/) to do the hard work.
 3. In your app's folder, run `python -m eel [your_main_script] [your_web_folder]` (for example, you might run `python -m eel hello.py web`)
 4. This will create a new folder `dist/`
 5. Valid PyInstaller flags can be passed through, such as excluding modules with the flag: `--exclude module_name`. For example, you might run `python -m eel file_access.py web --exclude win32com --exclude numpy --exclude cryptography`

--- a/eel/__main__.py
+++ b/eel/__main__.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import pkg_resources as pkg
 import PyInstaller.__main__ as pyi
 import os
 from argparse import ArgumentParser
@@ -25,12 +24,9 @@ web_folder = args.web_folder
 print("Building executable with main script '%s' and web folder '%s'...\n" %
       (main_script, web_folder))
 
-eel_js_file = pkg.resource_filename('eel', 'eel.js')
-js_file_arg = '%s%seel' % (eel_js_file, os.pathsep)
 web_folder_arg = '%s%s%s' % (web_folder, os.pathsep, web_folder)
 
-needed_args = ['--hidden-import', 'bottle_websocket',
-               '--add-data', js_file_arg, '--add-data', web_folder_arg]
+needed_args = ['--add-data', web_folder_arg]
 full_args = [main_script] + needed_args + unknown_args
 print('Running:\npyinstaller', ' '.join(full_args), '\n')
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(
         'eel': ['eel.js'],
     },
     install_requires=['bottle', 'bottle-websocket', 'future', 'whichcraft'],
+    extras_require={
+        "distribution": ['pyinstaller']
+    },
     python_requires='>=2.6',
     description='For little HTML GUI applications, with easy Python/JS interop',
     long_description=long_description,


### PR DESCRIPTION
PyInstaller now has a custom hook for Eel
(https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/6) that
tells it how to collect eel.js and our hidden imports
(bottle-websocket), so we don't need our own code to enable this.

We can also define a 'distribution' extra for Eel to additionally
install PyInstaller for the user.

**NOTE**: We need to wait for a release of PyInstaller that includes the new hook.