### PR TITLE
Add extras for templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Install from pypi with `pip`:
 pip install eel
 ```
 
+To include support for HTML templating, currently using [Jinja2](https://pypi.org/project/Jinja2/#description):
+
+```shell
+pip install eel[jinja2]
+```
+
 ## Usage
 
 ### Directory Structure

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(
         'eel': ['eel.js'],
     },
     install_requires=['bottle', 'bottle-websocket', 'future', 'whichcraft'],
+    extras_require={
+        "jinja2": ['jinja2>=2.10']
+    },
     python_requires='>=3.6',
     description='For little HTML GUI applications, with easy Python/JS interop',
     long_description=long_description,


### PR DESCRIPTION
One of our examples shows off the use of Jinja2 for templating HTML
files, but we don't make it easy or clear for users to know how to
enable support. This adds an entry to the readme and indicates supported
versions of Jinja2 via `extras_require` in `setup.py`