### PR TITLE
Fixes to getting Electron to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ As of Eel v0.12.0, the following options are available to `start()`:
  - **block**, a bool saying whether or not the call to `start()` should block the calling thread. *Default: `True`*
  - **jinja_templates**, a string specifying a folder to use for Jinja2 templates, e.g. `my_templates`. *Default:  `None`*
  - **cmdline_args**, a list of strings to pass to the command to start the browser. For example, we might add extra flags for Chrome; ```eel.start('main.html', mode='chrome-app', port=8080, cmdline_args=['--start-fullscreen', '--browser-startup-dialog'])```. *Default: `[]`*
+ - **custom_callback**, a callback function to be called when using `"custom"` mode which would be responsible for calling `subprocess.Popen` for example. It receives an array of command line arguments and an array of start urls in argument: `custom_callback(args, urls)`. If not set, the `cmdline_args` option is launched as the command to execute.
  - **size**, a tuple of ints specifying the (width, height) of the main window in pixels *Default: `None`*
  - **position**, a tuple of ints specifying the (left, top) of the main window in pixels *Default: `None`*
  - **geometry**, a dictionary specifying the size and position for all windows. The keys should be the relative path of the page, and the values should be a dictionary of the form `{'size': (200, 100), 'position': (300, 50)}`. *Default: {}*

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -294,9 +294,11 @@ def _process_message(message, ws):
 
 
 def _get_real_path(path):
-    if getattr(sys, 'frozen', False):
+    if getattr(sys, 'frozen', False) and hasattr(sys, "_MEIPASS"):
+        # Pyinstaller uses _MEIPASS for frozen paths
         return os.path.join(sys._MEIPASS, path)
     else:
+        # Unfrozen app or cx_freeze can use the path directly
         return os.path.abspath(path)
 
 

--- a/eel/browsers.py
+++ b/eel/browsers.py
@@ -48,8 +48,11 @@ def open(start_pages, options):
         pass
     elif mode == 'custom':
         # Just run whatever command the user provided
-        sps.Popen(options['cmdline_args'],
-                  stdout=sps.PIPE, stderr=sps.PIPE, stdin=sps.PIPE)
+        if options["custom_callback"]:
+            options["custom_callback"](options['cmdline_args'], start_urls)
+        else:
+            sps.Popen(options['cmdline_args'],
+                      stdout=sps.PIPE, stderr=sps.PIPE, stdin=sps.PIPE)
     elif mode in _browser_modules:
         # Run with a specific browser
         browser_module = _browser_modules[mode]

--- a/eel/electron.py
+++ b/eel/electron.py
@@ -15,7 +15,13 @@ def find_path():
     if sys.platform in ['win32', 'win64']:
         # It doesn't work well passing the .bat file to Popen, so we get the actual .exe
         bat_path = wch.which('electron')
-        return os.path.join(bat_path, r'..\node_modules\electron\dist\electron.exe')
+        if bat_path is not None:
+            exe_path = os.path.join(bat_path, r'..\node_modules\electron\dist\electron.exe')
+            if os.path.exists(exe_path):
+                return exe_path
+            else:
+                return bat_path
+        return None
     elif sys.platform in ['darwin', 'linux']:
         # This should work find...
         return wch.which('electron')


### PR DESCRIPTION
This PR includes 3 fixes. The first one is for #371 which I ended up forking/fixing, the other two were done in an attempt to get my app to run in electron for those that do not have chrome available. I wanted to include electron in my app, and found all sorts of issues, which this finally fixes.

The first issue I found is that setting the mode to "electron" on windows will cause an exception because if `which` returns None, you try a `os.path.join(None, "../node_modules/etc...") which will fail.

The second issue is that I realized that no matter what I did, it wouldn't work because the run command adds "." as an argument, and while removing it fixed it, I believe you had that in there on purpose because it specifies the current working directory for an electron bundle, and I didn't want to change that as it would break for those using a different system than what I'm doing.

Basically, I just downloaded the electron binaries from their releases, extracted it under a subdir, added it to the PATH, and I want to run it directly from there. There is no bat file, and no node_modules here, and launching electron with "." as its first argument will fail because my app's current dir is not an electron bundle. Using "custom" mode was the only solution, but that launches `cmdline_args` but without adding the url to it, and since I use `port=0` I had no way of hardcoding the url in the `cmdline_args` option either (and doing a block=false, and then trying to get the port to launch manually, and losing that whole websocket auto close thing, etc.. felt way too complicated than just adding a callback for `custom` modes).

So that's the explanation around where these commits are coming from, hopefully this gets accepted.
Thanks!