### PR TITLE
Fix jinja templating

### DIFF
--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -215,9 +215,9 @@ def _static(path):
     response = None
     if 'jinja_env' in _start_args and 'jinja_templates' in _start_args:
         template_prefix = _start_args['jinja_templates'] + '/'
-        if path.startswith(template_prefix):
+        if not path.startswith(template_prefix):
             n = len(template_prefix)
-            template = _start_args['jinja_env'].get_template(path[n:])
+            template = _start_args['jinja_env'].get_template(path)
             response = btl.HTTPResponse(template.render())
 
     if response is None:

--- a/eel/__init__.py
+++ b/eel/__init__.py
@@ -215,10 +215,8 @@ def _static(path):
     response = None
     if 'jinja_env' in _start_args and 'jinja_templates' in _start_args:
         template_prefix = _start_args['jinja_templates'] + '/'
-        if not path.startswith(template_prefix):
-            n = len(template_prefix)
-            template = _start_args['jinja_env'].get_template(path)
-            response = btl.HTTPResponse(template.render())
+        template = _start_args['jinja_env'].get_template(path)
+        response = btl.HTTPResponse(template.render())
 
     if response is None:
         response = btl.static_file(path, root=root_path)


### PR DESCRIPTION
When you were rendering a template, for example "index.html", the templating system would try to use "ndex.html" and it would not be found. This PR fixes that. I haven't seen an issue relating to this but I have seen it in my own testing.